### PR TITLE
Metrics API Update

### DIFF
--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -10,6 +10,7 @@ markers =
 	analogy
 	delete
 	exception
+	metrics
 	toolbelt
 	management
 	vectorspace

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -164,16 +164,13 @@ def test_delete_vector_space():
 
 
 @pytest.mark.metrics
-class TestMetrics:
-
-    # Test getting monthly usage from Vecto
-    def test_usage(self): 
-        from datetime import datetime
-        today = datetime.now()
-        usage_response = user_vecto.usage(user_vecto.vector_space_id, today.year, today.month)
-        logger.info("Checking that usage returns a valid response.")
-        assert usage_response is not None
-        logger.info("Checking that usage for today is not empty.")
-        assert usage_response.usage.lookups.dailyMetrics[today.day-1].count > 0
-        assert usage_response.usage.indexing.dailyMetrics[today.day-1].count > 0
+def test_usage(): 
+    from datetime import datetime
+    today = datetime.now()
+    usage_response = user_vecto.usage(today.year, today.month)
+    logger.info("Checking that usage returns a valid response.")
+    assert usage_response is not None
+    logger.info("Checking that usage for today is not empty.")
+    assert usage_response.usage.lookups.dailyMetrics[today.day-1].count > 0
+    assert usage_response.usage.indexing.dailyMetrics[today.day-1].count > 0
 

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -161,3 +161,19 @@ def test_delete_vector_space():
     id_exists = any(vecto_vector_space.id == test_vector_space.id for vecto_vector_space in updated_vs_list)
     logger.info("Check if the vector space is deleted.")
     assert not id_exists
+
+
+@pytest.mark.metrics
+class TestMetrics:
+
+    # Test getting monthly usage from Vecto
+    def test_usage(self): 
+        from datetime import datetime
+        today = datetime.now()
+        usage_response = user_vecto.usage(user_vecto.vector_space_id, today.year, today.month)
+        logger.info("Checking that usage returns a valid response.")
+        assert usage_response is not None
+        logger.info("Checking that usage for today is not empty.")
+        assert usage_response.usage.lookups.dailyMetrics[today.day-1].count > 0
+        assert usage_response.usage.indexing.dailyMetrics[today.day-1].count > 0
+

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -45,6 +45,10 @@ vecto_base_url = os.environ['vecto_base_url']
 user_vecto = Vecto(token, vector_space_id, vecto_base_url=vecto_base_url)
 user_db_twin = DatabaseTwin()
 
+# IDs for update apis
+ingest_text_ids = None
+ingest_image_ids = None
+
 # Clear off vector space before start
 @pytest.mark.clear
 def test_clear_vector_space_entries():
@@ -126,6 +130,10 @@ class TestIngesting:
         # for f in files:
         #     f.close()
         results = response.ids
+
+        global ingest_image_ids
+        ingest_image_ids = response.ids
+
         user_db_twin.update_database(results, data['data'])
         ref_db = user_db_twin.get_database()
 
@@ -166,6 +174,10 @@ class TestIngesting:
         attribute = TestDataset.get_text_attribute(batch.index.tolist()[:5], batch.tolist()[:5])
         response = user_vecto.ingest_text(batch.tolist()[:5], attribute)
         results = response.ids
+
+        global ingest_text_ids
+        ingest_text_ids = response.ids
+
         user_db_twin.update_database(results, attribute)
         ref_db = user_db_twin.get_database()
         
@@ -344,30 +356,30 @@ class TestUpdating:
     
     # Test updating a vector embedding using text on Vecto
     def test_update_single_text_vector_embedding(self):
-        text = TestDataset.get_random_text(TestDataset.get_color_dataset)
-        vector_ids = random.sample(range(len(text)), len(text))
+        text = TestDataset.get_random_text(TestDataset.get_color_dataset)[0]
+        global ingest_text_ids
+        vector_id = ingest_text_ids[0]
         
         updated_vector = []
-        
-        for file, vector_id in zip(text, vector_ids):
-            updated_vector.append({
+        updated_vector.append({
             'id': vector_id,
-            'data': io.StringIO(file),
+            'data': io.StringIO(text),
         })
 
         user_vecto.update_vector_embeddings(updated_vector, modality='TEXT')
 
     # Test updating a vector embedding using image on Vecto
     def test_update_single_image_vector_embedding(self):
-        image = TestDataset.get_random_image()
-        vector_ids = random.sample(range(len(image)), len(image))
+        image = TestDataset.get_random_image()[0]
+
+        global ingest_image_ids
+        vector_id = ingest_image_ids[0]
 
         updated_vector = []
         
-        for file, vector_id in zip(image, vector_ids):
-            updated_vector.append({
+        updated_vector.append({
             'id': vector_id,
-            'data': open(file, 'rb')
+            'data': open(image, 'rb')
         })
 
         user_vecto.update_vector_embeddings(updated_vector, modality='IMAGE')
@@ -378,7 +390,9 @@ class TestUpdating:
     # Test updating multiple vector embeddings using text on Vecto
     def test_update_batch_text_vector_embedding(self):
         text = TestDataset.get_color_dataset()[:5]
-        vector_ids = random.sample(range(len(text)), len(text))
+        
+        global ingest_text_ids
+        vector_ids = ingest_text_ids[:5]
 
         updated_vector = []
         
@@ -394,8 +408,9 @@ class TestUpdating:
     # Test updating multiple vector embeddings using image on Vecto
     def test_update_batch_image_vector_embedding(self):
         image = TestDataset.get_image_dataset()[:5]
-        vector_ids = random.sample(range(len(image)), len(image))
 
+        global ingest_image_ids
+        vector_ids = ingest_image_ids[:5]
         updated_vector = []
         
         for file, vector_id in zip(image, vector_ids):
@@ -411,7 +426,11 @@ class TestUpdating:
 
     # Test updating attribute of a vector embedding on Vecto
     def test_update_single_vector_attribute(self):
-        vector_id = random.randrange(0, 10)
+
+        old_results = user_vecto.lookup(io.StringIO('blue'), modality='TEXT', top_k=100)
+
+        global ingest_text_ids
+        vector_id = ingest_text_ids[0]
         new_attribute = 'new_attribute'
 
         updated_attribute = [{
@@ -421,7 +440,7 @@ class TestUpdating:
 
         user_vecto.update_vector_attribute(updated_attribute)
         ref_db = user_db_twin.get_database()
-
+        
         # Just a dummy lookup to return the specified ID - check specific entry
         f = io.StringIO('blue')
         lookup_response = user_vecto.lookup(f, modality='TEXT', top_k=1, ids=vector_id)
@@ -439,6 +458,7 @@ class TestUpdating:
         for result in lookup_response:
             if result.id != vector_id:
                 lookup_attribute.append([result.id, result.attributes])
+
         logger.info("Checking if other attribute is not updated...")
         for result in lookup_attribute:
             id = result[0]
@@ -449,7 +469,9 @@ class TestUpdating:
     # Test updating attribute of multiple vector embeddings on Vecto
     def test_update_vector_attribute(self):
         batch_len = 3
-        vector_ids = random.sample(range(10), batch_len)
+
+        global ingest_text_ids
+        vector_ids = ingest_text_ids[:3]
         new_attribute = ['new_attribute_{}'.format(i) for i in range(batch_len)]
 
         updated_attribute = []

--- a/vecto/schema.py
+++ b/vecto/schema.py
@@ -1,5 +1,6 @@
 import sys
 from typing import IO, NamedTuple, List, Optional
+from datetime import date
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict
@@ -98,3 +99,24 @@ class VectoAnalogy(NamedTuple):
     createdAt: str
     updatedAt: str
     vectorSpaceId: int
+
+class DailyUsageMetric(NamedTuple):
+    '''A named tuple that contains daily usage metrics.'''
+    date: date
+    count: int
+    cumulativeCount: int
+
+class UsageMetric(NamedTuple):
+    '''A named tuple that contains usage metrics, including an array of daily metrics.'''
+    dailyMetrics: List[DailyUsageMetric]
+
+class VectoUsageMetrics(NamedTuple):
+    '''A named tuple that contains Vecto usage metrics for lookups and indexing.'''
+    lookups: UsageMetric
+    indexing: UsageMetric
+
+class MonthlyUsageResponse(NamedTuple):
+    '''A named tuple that contains the usage metrics for a specified vector space and month.'''
+    year: int
+    month: int
+    usage: VectoUsageMetrics

--- a/vecto/vecto_requests.py
+++ b/vecto/vecto_requests.py
@@ -941,15 +941,25 @@ class Vecto():
             indexing=self._parse_usage_metric(u['indexing'])
         )
 
-    def usage(self, vector_space_id: int, year: int, month: int, **kwargs) -> MonthlyUsageResponse:
+    def usage(self, year: int, month: int, vector_space_id: int = None, **kwargs) -> MonthlyUsageResponse:
         '''Return the usage metrics for the selected month
 
         Args:
-            vector_space_id (int): The ID of the vector space.
             year (int): The year for the usage data.
             month (int): The month for the usage data.
+            vector_space_id (int, optional): The ID of the vector space. Defaults to None.
             **kwargs: Other keyword arguments for clients other than `requests`
+        Returns:
+            MonthlyUsageResponse: Named tuple that contains the usage metrics for a specified vector space and month.
         '''
+        
+        # Use provided vector_space_id or fallback to self.vector_space_id
+        vector_space_id = vector_space_id or getattr(self, 'vector_space_id', None)
+        
+        # Raise an error if vector_space_id is still not available
+        if vector_space_id is None:
+            raise ValueError("A vector space ID must be provided either as a parameter or set in the instance.")
+
         url = f"/api/v0/space/{vector_space_id}/usage/{year}/{month}"
         response = self._client.get(url, **kwargs)
         response_data = response.json()


### PR DESCRIPTION
This PR adds the `usage` metrics api, complete with the test.
It also fixes the `update` tests which relied on the twin database ids.